### PR TITLE
Update documentation for schema.js

### DIFF
--- a/lib/orm/schema.js
+++ b/lib/orm/schema.js
@@ -256,10 +256,16 @@ export default class Schema {
 
   /**
     Returns the first model in the database that matches the key-value pairs in `attrs`. Note that a string comparison is used.
+    Also remeber that attribute names are dasherized (for attributes with more than 1 word, like "createdAt" becomes "created-at")
 
     ```js
     let post = blogPosts.findBy({ published: true });
     ```
+    
+    Remember that relantionships are represented with a camelized `relationNameid` attribute name, so if you want to search for an author, you would do:
+    ```js
+    let post = blogPosts.findBy({ authorId: THE_AUTHOR_ID });
+    ``` 
 
     N.B. This will return `null` if the schema doesn't have any matching record.
 


### PR DESCRIPTION
The documentation on findBy does not remember users that searching for relations will need a "camelized" relation name (plus Id). And that attributes with more than one word are dasherized. This commit updates the documentation to address that